### PR TITLE
Upgrade pip before installing the server's dependencies

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,7 @@ FROM bvlc/caffe:cpu
 
 WORKDIR /app
 COPY requirements.txt requirements.txt
-# newer pip version to install jsonschema
+# newer pip version needed to install jsonschema
 RUN pip install --upgrade pip
 # install dependencies
 RUN pip install -r requirements.txt

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,7 +4,7 @@ FROM bvlc/caffe:cpu
 WORKDIR /app
 COPY requirements.txt requirements.txt
 # newer pip version needed to install jsonschema
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip setuptools
 # install dependencies
 RUN pip install -r requirements.txt
 #COPY . .

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,6 +3,8 @@ FROM bvlc/caffe:cpu
 
 WORKDIR /app
 COPY requirements.txt requirements.txt
+# newer pip version to install jsonschema
+RUN pip install --upgrade pip
 # install dependencies
 RUN pip install -r requirements.txt
 #COPY . .

--- a/server/Dockerfile.prod
+++ b/server/Dockerfile.prod
@@ -2,7 +2,7 @@ FROM bvlc/caffe:cpu
 WORKDIR /app
 # install dependencies
 COPY requirements.txt requirements.txt
-# newer pip version to install jsonschema
+# newer pip version needed to install jsonschema
 RUN pip install --upgrade pip
 # install dependencies
 RUN pip install -r requirements.txt

--- a/server/Dockerfile.prod
+++ b/server/Dockerfile.prod
@@ -3,7 +3,7 @@ WORKDIR /app
 # install dependencies
 COPY requirements.txt requirements.txt
 # newer pip version needed to install jsonschema
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip, setuptools
 # install dependencies
 RUN pip install -r requirements.txt
 COPY . .

--- a/server/Dockerfile.prod
+++ b/server/Dockerfile.prod
@@ -2,6 +2,9 @@ FROM bvlc/caffe:cpu
 WORKDIR /app
 # install dependencies
 COPY requirements.txt requirements.txt
+# newer pip version to install jsonschema
+RUN pip install --upgrade pip
+# install dependencies
 RUN pip install -r requirements.txt
 COPY . .
 # setup enviroment


### PR DESCRIPTION
This caused me a lot of problems when first setting up (it just didn't work), until I've upgraded pip before installing packages that depend on jsonschema. (jsonschema needs newer pip to build its dependencies)

The changes I am proposing fixed the issue for me. 