### PR TITLE
Fix permissions for node webapp Dockerfile

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,36 +1,20 @@
 # pull official base image
 FROM node:15.11-alpine
 
+#create home dir with user node access
 RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
 
-
+# set workdir and become user
 WORKDIR /home/node/app
-
 USER node
 
+# need to chown those as well
 COPY --chown=node:node package.json ./
 COPY --chown=node:node package-lock.json ./
 RUN npm install
 
-# set working directory
-#WORKDIR /home/node
-# add `/app/node_modules/.bin` to $PATH
-#ENV PATH /home/node/node_modules/.bin:$PATH
-# install app dependencies
-
-# To Fix Permissions for Packages
-#RUN npm config set unsafe-perm true
-
-#RUN npm install
-#RUN mkdir /app/node_modules/.cache && chmod -R 777 /app/node_modules/.cache
-
-#RUN chown -R node /app/node_modules
-
-#RUN mkdir -p /app/node_modules/.cache && chmod -R 777 /app/node_modules/.cache
-
-# add app
+# add app - yay, chown
 COPY --chown=node:node . .
 
-#USER node
 # start app
 CMD ["npm", "start"]

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,14 +1,36 @@
 # pull official base image
 FROM node:15.11-alpine
-# set working directory
-WORKDIR /app
-# add `/app/node_modules/.bin` to $PATH
-ENV PATH /app/node_modules/.bin:$PATH
-# install app dependencies
-COPY package.json ./
-COPY package-lock.json ./
+
+RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+
+
+WORKDIR /home/node/app
+
+USER node
+
+COPY --chown=node:node package.json ./
+COPY --chown=node:node package-lock.json ./
 RUN npm install
+
+# set working directory
+#WORKDIR /home/node
+# add `/app/node_modules/.bin` to $PATH
+#ENV PATH /home/node/node_modules/.bin:$PATH
+# install app dependencies
+
+# To Fix Permissions for Packages
+#RUN npm config set unsafe-perm true
+
+#RUN npm install
+#RUN mkdir /app/node_modules/.cache && chmod -R 777 /app/node_modules/.cache
+
+#RUN chown -R node /app/node_modules
+
+#RUN mkdir -p /app/node_modules/.cache && chmod -R 777 /app/node_modules/.cache
+
 # add app
-COPY . ./
+COPY --chown=node:node . .
+
+#USER node
 # start app
 CMD ["npm", "start"]


### PR DESCRIPTION
The setup requires handling the node user and to chown a bunch of files so they can be accessed later. Those changes should fix this.